### PR TITLE
Add authorisation for the Octokit

### DIFF
--- a/content/index.js
+++ b/content/index.js
@@ -5,7 +5,9 @@ import extractFrontMatter from 'front-matter'
 import { Octokit } from '@octokit/rest'
 import camelize from 'camelize'
 
-const octokit = new Octokit()
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+})
 
 const repo = {
   owner: 'oacore',


### PR DESCRIPTION
Increases the request rate limit to the GitHub REST API. To enable this, a `GITHUB_TOKEN` must be set in the OS environment.

You can create the token in your [profile settings](https://github.com/settings/tokens)