### PR TITLE
Fix NetlifyCMS after removing trailing slashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 .next
 out
 /public/design
-/public/edit
+/public/edit*
+/public/netlify-cms.config.*
 *.cache

--- a/netlify-cms.admin.html
+++ b/netlify-cms.admin.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="none">
 
+  <link rel="cms-config-url" href="/netlify-cms.config.yml" type="text/yaml">
+
   <title>CORE Admin</title>
 
   <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "test-staging": "blc https://${CORE_STAGING_AREA}core.ac.uk -ro --exclude='/browse' --exclude='/search' --exclude='/public'",
     "test": "npm run test-dev",
     "dev": "next",
-    "prebuild": "mkdir -p public/edit && cp netlify-cms.admin.html public/edit/index.html && cp netlify-cms.config.yml public/edit/config.yml",
+    "prebuild": "cp netlify-cms.admin.html public/edit.html && cp netlify-cms.config.yml public/",
     "build": "next build",
     "preexport": "npm run build",
     "export": "next export",


### PR DESCRIPTION
When there is `trailingSlash: false` in the `next.config.js`, the framework always redirect to the route without slash. Hence, the URL under `/public/edit/*` is not resolved.

This changes the NetlifyCMS deployment to resolve the `config.yml` always from the specific location and moves `/public/edit/index.html` to bare `/public/edit.html` preventing the confusion with the trailing slash redirect.