### PR TITLE
Add Terms and Conditions page

### DIFF
--- a/data/terms.md
+++ b/data/terms.md
@@ -1,0 +1,69 @@
+---
+title: CORE Terms and Conditions
+---
+
+<!-- <p>By using this service you are agreeing to the following usage criteria.</p> -->
+
+<style>
+  ol p + ol, ol p + ul, ul p + ol, ul p + ul {
+    margin-bottom: 1.5rem;
+  }
+</style>
+
+
+## CC-BY licenced datasets
+
+1.  You can use these datasets for any commercial or non-commercial
+  purposes in line with the&nbsp;CC-BY licence.
+
+2.  You need to acknowledge the use of CORE as [described](/acknowledge).
+
+
+## Other datasets and the API
+
+You should [contact us](mailto:th%65%74eam%40c%6fr%65%2eac%2eu%6b)
+in any case (even if one of the below points apply to you) if:
+
+1.  You are developing or intending to develop services using
+    CORE data that might be either:
+
+    - monetised now or in the future <b>OR</b>
+    - serve only a restricted group of beneficiaries&nbsp;(e.g.&nbsp;only
+      your own organisation)
+
+2.  You are developing a service for everyone that is related to
+    the functionality provided by one of CORE’s existing services,
+    such as but not limited to an API, a recommender system,
+    search, discovery system or analytical dashboard.
+
+If you are **an individual**, you can use CORE data freely if:
+
+1.  You are conducting work in your own personal
+    capacity <b>AND</b>
+2.  No revenue is expected to result from
+    the work <b>AND</b>
+3.  You will comply with our Terms and Conditions
+    for free use <b>AND</b>
+4.  You will acknowledge the use of CORE as [described](/acknowledge).
+
+If you are working for **a public research
+organisation**&nbsp;(e.g.&nbsp;a&nbsp;university):
+
+1.  You can use CORE data freely if:
+
+    - You are pursuing research on CORE data with
+      the objective of producing a research paper or
+      a publicly available report <b>AND</b>
+    - You will comply with our Terms and Conditions
+      for free use <b>AND</b>
+    - You will acknowledge the use of CORE as [described](/acknowledge).
+
+2.  If you are intending to use CORE as part of
+    a research project(s) then you should 
+    [contact us](mailto:th%65%74eam%40c%6fr%65%2eac%2eu%6b)
+    to obtain a licence.
+
+[Contact us](mailto:th%65%74eam%40c%6fr%65%2eac%2eu%6b)
+to discuss use of CORE data in all **other** cases.
+
+</section>

--- a/data/terms.md
+++ b/data/terms.md
@@ -14,7 +14,7 @@ title: CORE Terms and Conditions
 ## CC-BY licenced datasets
 
 1.  You can use these datasets for any commercial or non-commercial
-  purposes in line with the&nbsp;CC-BY licence.
+    purposes in line with the&nbsp;CC-BY licence.
 
 2.  You need to acknowledge the use of CORE as [described](/acknowledge).
 
@@ -36,7 +36,9 @@ in any case (even if one of the below points apply to you) if:
     such as but not limited to an API, a recommender system,
     search, discovery system or analytical dashboard.
 
-If you are **an individual**, you can use CORE data freely if:
+### Individuals
+
+If you are an individual, you can use CORE data freely if:
 
 1.  You are conducting work in your own personal
     capacity <b>AND</b>
@@ -46,8 +48,11 @@ If you are **an individual**, you can use CORE data freely if:
     for free use <b>AND</b>
 4.  You will acknowledge the use of CORE as [described](/acknowledge).
 
-If you are working for **a public research
-organisation**&nbsp;(e.g.&nbsp;a&nbsp;university):
+
+### Public research organisations
+
+If you are working for a public research
+organisation&nbsp;(e.g.&nbsp;a&nbsp;university):
 
 1.  You can use CORE data freely if:
 
@@ -63,7 +68,9 @@ organisation**&nbsp;(e.g.&nbsp;a&nbsp;university):
     [contact us](mailto:th%65%74eam%40c%6fr%65%2eac%2eu%6b)
     to obtain a licence.
 
+### Others
+
 [Contact us](mailto:th%65%74eam%40c%6fr%65%2eac%2eu%6b)
-to discuss use of CORE data in all **other** cases.
+to discuss use of CORE data in all other cases.
 
 </section>

--- a/data/terms.md
+++ b/data/terms.md
@@ -2,8 +2,6 @@
 title: CORE Terms and Conditions
 ---
 
-<!-- <p>By using this service you are agreeing to the following usage criteria.</p> -->
-
 <style>
   ol p + ol, ol p + ul, ul p + ol, ul p + ul {
     margin-bottom: 1.5rem;

--- a/pages/terms.jsx
+++ b/pages/terms.jsx
@@ -1,0 +1,4 @@
+import { MarkdownPage } from 'components/pages'
+import page from 'data/terms.md'
+
+export default MarkdownPage.create(page)


### PR DESCRIPTION
Moves API and Dataset terms and conditions from the registration pages to a separate page here. This saves some space on the registration pages for forms and makes them more scan-able. This might be a questionable strategic decision though.